### PR TITLE
Fix date being off-centre

### DIFF
--- a/dynamic-calendar-and-clocks-icons-reborn@thecalamityjoe87.github.com/extension.js
+++ b/dynamic-calendar-and-clocks-icons-reborn@thecalamityjoe87.github.com/extension.js
@@ -379,7 +379,8 @@ function repaintCalendar(icon) {
     context.setSourceRGB(dateR, dateG, dateB);
     context.selectFontFace(dateFont, 0, dateBold);
     context.setFontSize(iconSize / 96 * dateSize);
-    let dateX = (iconSize - context.textExtents(date).width) / 2;
+    let dateExtents = context.textExtents(date);
+    let dateX = (iconSize - dateExtents.width) / 2 - dateExtents.xBearing;
     datePos = showWeekday || showMonth ? datePos : dateOnlyPos;
     context.moveTo(dateX, iconSize / 96 * datePos);
     context.showText(date);
@@ -408,7 +409,8 @@ function repaintSymbolicCalendar(icon) {
     context.setSourceRGB(symDateR, symDateG, symDateB);
     context.selectFontFace(symDateFont, 0, symDateBold);
     context.setFontSize(iconSize / 16 * symDateSize);
-    let dateX = (iconSize - context.textExtents(date).width) / 2;
+    let dateExtents = context.textExtents(date);
+    let dateX = (iconSize - dateExtents.width) / 2 - dateExtents.xBearing;
     context.moveTo(dateX, iconSize / 16 * symDatePos);
     context.showText(date);
     context.$dispose();


### PR DESCRIPTION
It's a one pixel difference, but I couldn't unsee it. This fixes it by offsetting by the transparent portion of the left side of the date text. 

Before:
<img width="86" height="93" alt="image" src="https://github.com/user-attachments/assets/2f045233-66ff-411e-bb0a-a4f8a96b245c" />

After:
<img width="70" height="102" alt="image" src="https://github.com/user-attachments/assets/f105af00-6216-4806-a9ec-1ef233acde10" />
